### PR TITLE
Make states visible before/at the same time as cities

### DIFF
--- a/styles/bright/style.json
+++ b/styles/bright/style.json
@@ -2298,7 +2298,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "boundary",
-      "minzoom": 5,
+      "minzoom": 2,
       "filter": [
         "all",
         [">=", ["get", "admin_level"], 3],
@@ -3007,7 +3007,7 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "place",
-      "minzoom": 5,
+      "minzoom": 3,
       "maxzoom": 8,
       "filter": ["==", ["get", "class"], "state"],
       "layout": {

--- a/styles/liberty/style.json
+++ b/styles/liberty/style.json
@@ -2026,7 +2026,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "boundary",
-      "minzoom": 5,
+      "minzoom": 2,
       "filter": [
         "all",
         [">=", ["get", "admin_level"], 3],
@@ -2663,7 +2663,7 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "place",
-      "minzoom": 5,
+      "minzoom": 3,
       "maxzoom": 8,
       "filter": ["==", ["get", "class"], "state"],
       "layout": {

--- a/styles/positron/style.json
+++ b/styles/positron/style.json
@@ -880,7 +880,7 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "boundary",
-      "minzoom": 8,
+      "minzoom": 2,
       "filter": [
         "all",
         [">=", ["get", "admin_level"], 3],
@@ -1367,7 +1367,7 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "place",
-      "minzoom": 5,
+      "minzoom": 3,
       "maxzoom": 8,
       "filter": ["==", ["get", "class"], "state"],
       "layout": {


### PR DESCRIPTION
Previous minzoom value of 5 meant that to see state borders you would have to zoom in far enough that only 2-3 US states would fit on the screen. The new values of 2 and 3 are a good match for the original versions of these styles.