### PR TITLE
fix `boundary_3` filters against `null` `admin_level`

### DIFF
--- a/styles/bright/style.json
+++ b/styles/bright/style.json
@@ -2301,6 +2301,7 @@
       "minzoom": 5,
       "filter": [
         "all",
+        ["==", ["typeof", ["get", "admin_level"]], "number"],
         [">=", ["get", "admin_level"], 3],
         ["<=", ["get", "admin_level"], 6],
         ["!=", ["get", "maritime"], 1],

--- a/styles/liberty/style.json
+++ b/styles/liberty/style.json
@@ -2029,6 +2029,7 @@
       "minzoom": 5,
       "filter": [
         "all",
+        ["==", ["typeof", ["get", "admin_level"]], "number"],
         [">=", ["get", "admin_level"], 3],
         ["<=", ["get", "admin_level"], 6],
         ["!=", ["get", "maritime"], 1],

--- a/styles/positron/style.json
+++ b/styles/positron/style.json
@@ -883,6 +883,7 @@
       "minzoom": 8,
       "filter": [
         "all",
+        ["==", ["typeof", ["get", "admin_level"]], "number"],
         [">=", ["get", "admin_level"], 3],
         ["<=", ["get", "admin_level"], 6],
         ["!=", ["get", "maritime"], 1],


### PR DESCRIPTION
Closes https://github.com/hyperknot/openfreemap/issues/107

Add a numeric typeof guard before `admin_level` range comparisons in bright, liberty, and positron styles to prevent runtime expression type errors when boundary features contain null values.

FYI: Made-with Cursor